### PR TITLE
Fix TypeError when docutils can't provide a line

### DIFF
--- a/src/autodoc2/analysis.py
+++ b/src/autodoc2/analysis.py
@@ -40,7 +40,7 @@ def analyse_module(
     if not file_path.is_dir():
         node = AstroidBuilder().file_build(os.fsdecode(file_path), name)
     else:
-        node = build_namespace_package_module(name, file_path.parts)
+        node = build_namespace_package_module(name, [str(file_path)])
     yield from walk_node(
         node, State(node.name.split(".", 1)[0], [], exclude_external_imports)
     )

--- a/src/autodoc2/sphinx/docstring.py
+++ b/src/autodoc2/sphinx/docstring.py
@@ -139,7 +139,7 @@ class DocstringRenderer(SphinxDirective):
                 )
                 document.reporter.get_source_and_line = lambda li: (
                     source_path,
-                    li + source_offset,
+                    li + source_offset if li is not None else None,
                 )
                 with parsing_context():
                     parser.parse(item["doc"], document)
@@ -214,7 +214,7 @@ def change_source(
         state.reporter.source = source_path
         state.reporter.get_source_and_line = lambda li: (
             source_path,
-            li + line_offset,
+            li + line_offset if li is not None else None,
         )
         yield
     finally:


### PR DESCRIPTION
Since a namespace pkg does not have a file, we need to fix the line number reporter so it does not try to compute a line number when there is None.

As discussed here:

https://github.com/sphinx-extensions2/sphinx-autodoc2/pull/69#issuecomment-2365758453